### PR TITLE
Minor edit in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ quillEditor.on('text-change', function(delta, oldDelta, source) {
 });
 
 function onReceiveDelta(delta) {
-  // If this delta was sent by this client they also need to call otClient.serverAck();
+  // If this delta was sent by this client they need to call `otClient.serverAck()` instead
   otClient.applyFromServer(delta);
 }
 ```  

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ quillEditor.on('text-change', function(delta, oldDelta, source) {
 });
 
 function onReceiveDelta(delta) {
-  // If this delta was sent by this client they need to call `otClient.serverAck()` instead
+  // If this delta was sent by this client they need to call otClient.serverAck() instead
+  // this prevents deltas that have already been applied by the user from being applied twice
   otClient.applyFromServer(delta);
 }
 ```  


### PR DESCRIPTION
Thanks for this. I have been using this for [Jotpad](https://github.com/arslnb/jotpad). I've tweaked the documentation with the intent to make it easier to use/understand for everybody. 

In my understanding, **only** `otClient.serverAck()` should be called when a delta is received from the server and it is found that the client receiving it is the author of that delta. 

The documentation originally suggested that `otClient.serverAck()` should **also** be called (which may be interpreted as "in combination with `otClient.applyFromServer(delta)`) which results in the author client seeing each delta applied twice, and subsequently messing up indexes on future deltas. 

Hope this helps. 